### PR TITLE
Fix location pin extraction

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -197,7 +197,8 @@ class HealthCheckProfileForm(BaseFormAction):
         tracker: Tracker,
         domain: Dict[Text, Any],
     ) -> Dict[Text, Optional[Text]]:
-        metadata = tracker.latest_message.get("metadata")
+        latest_message = tracker.get_last_event_for("user")
+        metadata = latest_message.get("metadata")
 
         # Use location pin data if submitted
         if metadata and metadata.get("type") == "location":
@@ -206,7 +207,12 @@ class HealthCheckProfileForm(BaseFormAction):
             address = metadata["location"].get("address")
             if not address:
                 address = f"GPS: {latitude}, {longitude}"
-            return {"location": address, "latitude": latitude, "longitude": longitude}
+            return {
+                "location": address,
+                "latitude": latitude,
+                "longitude": longitude,
+                "location_confirm": "yes",
+            }
 
         if not value:
             dispatcher.utter_message(template="utter_incorrect_selection")

--- a/domain.yml
+++ b/domain.yml
@@ -159,7 +159,7 @@ responses:
 
   utter_ask_location_confirm:
     - text: |
-        We use Google Location Services to verify locations. Please confirm that the address below is correct based on the information you have shared:\n
+        We use Google Location Services to verify locations. Please confirm that the address below is correct based on the information you have shared:
         ----------------------------
         {location}
         ----------------------------


### PR DESCRIPTION
It seems like the `tracker` in a form is not the same as the `tracker` in rasa core, which means that `tracker.get_last_message` just returns a dictionary, which doesn't have any metadata.

We can use `tracker.get_last_event` to get the last message instead, which is a dictionary with the full event, instead of whatever is in `tracker.get_last_event`.

I've used the magic string `"user"` here, because I can't find anywhere in Rasa SDK where these strings are being stored. It seems like in their own code they just use the string directly, instead of something like `UserUttered.type_name`