### PR TITLE
Use separate location and city_location for submitting data

### DIFF
--- a/actions/actions.py
+++ b/actions/actions.py
@@ -655,7 +655,6 @@ class HealthCheckForm(BaseFormAction):
                 try:
                     async with HTTPXClient() as client:
                         resp = await client.post(url, json=post_data, headers=headers)
-                        logging.debug(resp.text)
                         resp.raise_for_status()
                         break
                 except httpx.HTTPError as e:

--- a/domain.yml
+++ b/domain.yml
@@ -55,10 +55,10 @@ slots:
   location_confirm:
     type: unfeaturized
     auto_fill: false
-  latitude:
+  location_coords:
     type: unfeaturized
     auto_fill: false
-  longitude:
+  city_location_coords:
     type: unfeaturized
     auto_fill: false
   medical_condition:


### PR DESCRIPTION
In other apps, we use the `location` field for when the data is from a location pin, and `city_location` if it's derived from a freetext input, so we should do the same here