### PR TITLE
Fix returning user journey

### DIFF
--- a/data/stories.md
+++ b/data/stories.md
@@ -1,8 +1,12 @@
 ## happy path
 * request_healthcheck
-    - action_reset_all_but_few_slots
+    - slot{"terms": null}
+    - utter_welcome
     - healthcheck_terms_form
     - form{"name": "healthcheck_terms_form"}
+    - slot{"terms": null}
+    - slot{"terms": "yes"}
+    - form{"name": null}
     - healthcheck_profile_form
     - form{"name": "healthcheck_profile_form"}
     - form{"name": null}
@@ -10,3 +14,25 @@
     - healthcheck_form
     - form{"name": "healthcheck_form"}
     - form{"name": null}
+    - action_session_start
+
+## happy path returning user
+* request_healthcheck
+    - slot{"terms": "yes"}
+    - utter_welcome_back
+    - healthcheck_profile_form
+    - form{"name": "healthcheck_profile_form"}
+    - form{"name": null}
+    - utter_start_health_check
+    - healthcheck_form
+    - form{"name": "healthcheck_form"}
+    - form{"name": null}
+    - action_session_start
+
+## session start new
+    - action_session_start
+    - slot{"terms": null}
+
+## session start returning
+    - action_session_start
+    - slot{"terms": "yes"}

--- a/domain.yml
+++ b/domain.yml
@@ -11,7 +11,7 @@ entities:
   - number
 
 actions:
-  - action_reset_all_but_few_slots
+  - action_session_start
   - utter_ask_terms
   - utter_ask_age
   - utter_ask_gender

--- a/domain.yml
+++ b/domain.yml
@@ -359,5 +359,5 @@ responses:
         📌Reply with *TESTING* for more information or *MENU* to return to the main menu
 
 session_config:
-  session_expiration_time: 1
+  session_expiration_time: 5
   carry_over_slots_to_new_session: true

--- a/domain.yml
+++ b/domain.yml
@@ -38,8 +38,9 @@ actions:
 
 slots:
   terms:
-    type: unfeaturized
-    auto_fill: false
+    type: categorical
+    values:
+      - yes
   age:
     type: unfeaturized
     auto_fill: false

--- a/tests/conversation_tests.md
+++ b/tests/conversation_tests.md
@@ -3,7 +3,8 @@
 
 ## happy path healthcheck
 * request_healthcheck: check
-  - action_reset_all_but_few_slots
+  - slot{"terms": null}
+  - utter_welcome
   - healthcheck_terms_form
   - form{"name": "healthcheck_terms_form"}
   - form{"name": null}
@@ -14,3 +15,17 @@
   - healthcheck_form
   - form{"name": "healthcheck_form"}
   - form{"name": null}
+  - action_session_start
+
+## happy path healthcheck returning user
+* request_healthcheck: check
+  - slot{"terms": "yes"}
+  - utter_welcome_back
+  - healthcheck_profile_form
+  - form{"name": "healthcheck_profile_form"}
+  - form{"name": null}
+  - utter_start_health_check
+  - healthcheck_form
+  - form{"name": "healthcheck_form"}
+  - form{"name": null}
+  - action_session_start


### PR DESCRIPTION
This PR does a few things:
- Overrides the session_start action, to only copy over the fields we want, not all fields (and get rid of the old action that was doing that)
- Uses a featurized field, and user stories, to differentiate between the new and returning user stories
- Moves the welcome message vs welcome back message to those separate stories
- Adds a session_start action to the end of the stories. There's no end session action, so we instead do a session start, so that if the user starts another healthcheck before the timeout, it does the correct thing.
- Changes the session timeout from 1 minute to 5 minutes