### PR TITLE
Add story for exit action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+          pip install -r actions/requirements-actions.txt
       - name: Lint
         run: |
           black --check actions

--- a/data/stories.md
+++ b/data/stories.md
@@ -36,3 +36,9 @@
 ## session start returning
     - action_session_start
     - slot{"terms": "yes"}
+
+## exit
+* exit
+    - action_exit
+    - slot{"terms": null}
+    - action_listen


### PR DESCRIPTION
The custom action ends with an `action_listen`, but rasa core doesn't seem to recognise that. So we need to add a story, so that Rasa core knows to do an `action_listen` after the `action_exit`