### PR TITLE
Add Parent profile

### DIFF
--- a/base/actions/actions.py
+++ b/base/actions/actions.py
@@ -55,13 +55,19 @@ class BaseFormAction(FormAction):
         dispatcher: CollectingDispatcher,
         value: Text,
         data: Dict[int, Text],
+        accept_labels=True,
     ) -> Dict[Text, Optional[Text]]:
         """
         Validates that the value is either:
         - One of the values
         - An integer that is one of the keys
         """
-        if value and isinstance(value, str) and value.lower() in data.values():
+        if (
+            accept_labels
+            and value
+            and isinstance(value, str)
+            and value.lower() in data.values()
+        ):
             return {field: value}
         elif self.is_int(value) and int(value) in data:
             return {field: data[int(value)]}

--- a/dbe/actions/actions.py
+++ b/dbe/actions/actions.py
@@ -137,7 +137,9 @@ class HealthCheckProfileForm(BaseHealthCheckProfileForm):
         tracker: Tracker,
         domain: Dict[Text, Any],
     ) -> Dict[Text, Optional[Text]]:
-        return self.validate_generic("profile", dispatcher, value, self.profile_data)
+        return self.validate_generic(
+            "profile", dispatcher, value, self.profile_data, accept_labels=False
+        )
 
     validate_obo_age = obo_validator(validate_age)
     validate_obo_gender = obo_validator(BaseHealthCheckProfileForm.validate_gender)

--- a/dbe/data/lookup_tables/profiles.txt
+++ b/dbe/data/lookup_tables/profiles.txt
@@ -1,4 +1,5 @@
 educator
 learner
 parent
+actual_parent
 support

--- a/dbe/domain-eng.yml
+++ b/dbe/domain-eng.yml
@@ -200,8 +200,9 @@ responses:
           Reply
           *1.* Educator
           *2.* Learner
-          *3.* Parents or Guardian on behalf of learner
-          *4.* Support or Admin staff
+          *3.* Parents / Guardian on behalf of learner
+          *4.* Parent
+          *5.* Support or Admin staff
 
   utter_more_terms:
       - text: |

--- a/dbe/tests/test_actions.py
+++ b/dbe/tests/test_actions.py
@@ -83,13 +83,16 @@ class HealthCheckProfileFormTests(TestCase):
 
     def test_validate_profile(self):
         """
-        Get the profile of the user
+        Get the profile of the user. Should not accept labels.
         """
         form = HealthCheckProfileForm()
         tracker = Tracker("27820001001", {}, {}, [], False, None, {}, "action_listen")
         dispatcher = CollectingDispatcher()
         response = form.validate_profile("4", dispatcher, tracker, {})
-        self.assertEqual(response, {"profile": "support"})
+        self.assertEqual(response, {"profile": "actual_parent"})
+
+        response = form.validate_profile("parent", dispatcher, tracker, {})
+        self.assertEqual(response, {"profile": None})
 
     def test_slot_mappings(self):
         """


### PR DESCRIPTION
This adds a profile for parents to complete the healthcheck themselves (instead of on behalf of their children).

We have to name this profile `actual_parent`, since `parent` is already taken by the parents on behalf of child (and we can't easily migrate all that data).

For this reason, I've also had it ignore the labels for this question, because we don't want them to type `parent`, and then be classified as parent on behalf of child. This means that they will have to reply with numbers.