### PR TITLE
change boston college incorrect spelling

### DIFF
--- a/hh/actions/university_data.yaml
+++ b/hh/actions/university_data.yaml
@@ -792,7 +792,7 @@ mp:
   Vaal University of Technology (VUT):
   - Secunda
   Boston City Campus & Business College:
-  - Wtibank
+  - Witbank
   - Mbombela
   Centurion Akademie:
   - Witbank
@@ -982,7 +982,7 @@ wc:
   - Cape Town
   - George
   - Paarl
-  - Belville
+  - Bellville
   Camelot International:
   - Cape Town
   Cape Audio College:


### PR DESCRIPTION
[COV-1029](https://praekeltorg.atlassian.net/browse/COV-1029)

Belville -> Bellville
Wtibank -> Witbank