### PR TITLE
Fix additional slots for returning users

### DIFF
--- a/dbe/actions/actions.py
+++ b/dbe/actions/actions.py
@@ -82,11 +82,16 @@ class HealthCheckProfileForm(BaseHealthCheckProfileForm):
         slots = super().required_slots(tracker)
         if tracker.get_slot("returning_user") == "yes":
             if tracker.get_slot("change_details"):
-                slots = ["province", "school", "school_confirm", "confirm_details"]
+                slots = [
+                    "province",
+                    "school",
+                    "school_confirm",
+                    "confirm_details",
+                ] + slots
             elif tracker.get_slot("confirm_details") == "no":
-                return ["change_details"]
+                slots = ["change_details"] + slots
             elif not tracker.get_slot("confirm_details"):
-                return ["confirm_details"]
+                slots = ["confirm_details"] + slots
         # Use on behalf of slots for parent profile
         if tracker.get_slot("profile") == "parent":
             slots = ["profile", "obo_name", "obo_age"] + [

--- a/dbe/tests/test_actions.py
+++ b/dbe/tests/test_actions.py
@@ -185,6 +185,20 @@ class HealthCheckProfileFormTests(TestCase):
         slots = HealthCheckProfileForm.required_slots(tracker)
         self.assertEqual(slots, ["confirm_details"])
 
+    def test_required_slots_returning_user_additional(self):
+        """
+        For returning users, after confirming information, if there are any additional
+        slots that we still need to fill, we should ask them
+        """
+        tracker = Tracker("27820001001", {}, {}, [], False, None, {}, "action_listen")
+        tracker.slots["province_display"] = "WESTERN CAPE"
+        tracker.slots["school"] = "BERGVLIET HIGH SCHOOL"
+        tracker.slots["returning_user"] = "yes"
+        tracker.slots["confirm_details"] = "yes"
+        tracker.slots["profile"] = "learner"
+        slots = HealthCheckProfileForm.required_slots(tracker)
+        self.assertEqual(slots, ["age"])
+
     def test_end_of_form_parent(self):
         """
         For the parent profile, if all the fields are filled, then we should return


### PR DESCRIPTION
For returning users, if there are additional slots that still need to be filled, then we should ask them after asking the user to confirm their details.