### PR TITLE
OR clause between search terms

### DIFF
--- a/dbe/actions/actions.py
+++ b/dbe/actions/actions.py
@@ -7,7 +7,7 @@ from rasa_sdk import Action, Tracker
 from rasa_sdk.events import ActionExecuted, SessionStarted, SlotSet
 from rasa_sdk.executor import CollectingDispatcher
 from whoosh.index import open_dir
-from whoosh.qparser import MultifieldParser
+from whoosh.qparser import MultifieldParser, OrGroup
 from whoosh.query import FuzzyTerm, Term
 
 from base.actions.actions import HealthCheckForm as BaseHealthCheckForm
@@ -308,7 +308,9 @@ class HealthCheckProfileForm(BaseHealthCheckProfileForm):
         if value and isinstance(value, str) and value.strip().lower() == "other":
             return {"school": "OTHER", "school_emis": None, "school_confirm": "yes"}
         ix = open_dir("dbe/actions/emis_index")
-        parser = MultifieldParser(["name", "emis"], ix.schema, termclass=FuzzyTerm)
+        parser = MultifieldParser(
+            ["name", "emis"], ix.schema, termclass=FuzzyTerm, group=OrGroup
+        )
         query = parser.parse(value)
 
         province = tracker.get_slot("obo_province") or tracker.get_slot("province")

--- a/dbe/tests/test_actions.py
+++ b/dbe/tests/test_actions.py
@@ -48,6 +48,21 @@ class HealthCheckProfileFormTests(TestCase):
             response, {"school": "BERGVLIET HIGH SCHOOL", "school_emis": "105310201"}
         )
 
+    def test_validate_school_or_clause(self):
+        """
+        The search should be an OR between terms
+        """
+        form = HealthCheckProfileForm()
+        tracker = Tracker(
+            "27820001001", {"province": "fs"}, {}, [], False, None, {}, "action_listen"
+        )
+        response = form.validate_school(
+            "bedelia primary", CollectingDispatcher(), tracker, {}
+        )
+        self.assertEqual(
+            response, {"school": "BEDELIA P/S", "school_emis": "444712090"}
+        )
+
     def test_validate_school_other(self):
         """
         Stores the school as other and moves on


### PR DESCRIPTION
Currently the search defaults to an AND clause, and because of how things are put into the database, this leads to matches that you would expect not being made. eg. In the database, there's a `BEDELIA P/S`, so when you search `bedelia primary`, it finds no matches. Changing to an OR clause should fix that.