### PR TITLE
Ensure that the no_consent_parent message is sent if terms rejected

### DIFF
--- a/dbe/actions/actions.py
+++ b/dbe/actions/actions.py
@@ -98,6 +98,7 @@ class DBEHealthCheckTermsForm(BaseHealthCheckTermsForm):
             after all required slots are filled"""
         if tracker.get_slot("terms") == "no":
             tracker.slots["terms"] = None
+            dispatcher.utter_message(template="utter_no_consent_parent")
             return await ActionExit().run(dispatcher, tracker, domain)
         return []
 

--- a/dbe/tests/test_actions.py
+++ b/dbe/tests/test_actions.py
@@ -87,8 +87,9 @@ async def test_deny_terms():
         {},
     )
     assert SlotSet("terms", None) in events
-    [message] = dispatcher.messages
-    assert message["template"] == "utter_exit"
+    [message1,message2] = dispatcher.messages
+    assert message1["template"] == "utter_no_consent_parent"
+    assert message2["template"] == "utter_exit"
 
 
 @pytest.mark.asyncio

--- a/dbe/tests/test_actions.py
+++ b/dbe/tests/test_actions.py
@@ -87,7 +87,7 @@ async def test_deny_terms():
         {},
     )
     assert SlotSet("terms", None) in events
-    [message1,message2] = dispatcher.messages
+    [message1, message2] = dispatcher.messages
     assert message1["template"] == "utter_no_consent_parent"
     assert message2["template"] == "utter_exit"
 


### PR DESCRIPTION
Locally and in tests the utter_exit message is being sent if the terms are rejected but in QA nothing is being sent to the user.
The no_consent_parent message is what is supposed to be sent. So this sends both